### PR TITLE
`pytest_collection_modifyitems` should try to run last instead of first

### DIFF
--- a/src/pytest_split/plugin.py
+++ b/src/pytest_split/plugin.py
@@ -130,7 +130,7 @@ class PytestSplitPlugin(Base):
             )
             self.writer.line(message)
 
-    @hookimpl(tryfirst=True)
+    @hookimpl(trylast=True)
     def pytest_collection_modifyitems(self, config: "Config", items: "List[nodes.Item]") -> None:
         """
         Collect and select the tests we want to run, and deselect the rest.


### PR DESCRIPTION
Fixes #17 where tests are incorrectly split if paired with mark expressions. Thanks for this great plugin, by the way. 🙌 