### PR TITLE
Update PR template to render empty checkboxes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,6 @@ A short description about the changes in this pull request. If the pull request 
 
 ## Checklist
 
-- [] Tests covering the new functionality have been added
-- [] Documentation has been updated OR the changes are too minor to be documented
-- [] The Changes are listed in the `CHANGELOG.md` OR the changes are insignificant
+- [ ] Tests covering the new functionality have been added
+- [ ] Documentation has been updated OR the changes are too minor to be documented
+- [ ] The Changes are listed in the `CHANGELOG.md` OR the changes are insignificant


### PR DESCRIPTION
## Description

Noticed on [my other PR](https://github.com/jerry-git/pytest-split/pull/55) that when leaving boxes unchecked the formatting is kinda broken. When adding a space between the brackets, github renders empty checkboxes, so this updates the PR template to do that. I left one of both ways of writing it on the other PR to demonstrate.

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the changes are too minor to be documented
- [x] The Changes are listed in the `CHANGELOG.md` OR the changes are insignificant
