### PR TITLE
Fix deprecated pytest API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Changed
 - Introduce Ruff
+- Fixed usage of [deprecated pytest API](https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers)
+
 
 ## [0.8.0] - 2022-04-22
 ### Fixed

--- a/src/pytest_split/plugin.py
+++ b/src/pytest_split/plugin.py
@@ -76,7 +76,7 @@ def pytest_addoption(parser: "Parser") -> None:
     )
 
 
-@pytest.mark.tryfirst()
+@pytest.hookimpl(tryfirst=True)
 def pytest_cmdline_main(config: "Config") -> "Optional[Union[int, ExitCode]]":
     """
     Validate options.


### PR DESCRIPTION
pytest-split uses deprecated API from pytest for hook implementation. Result of that is a warning message showed to user:
```
pytest_split/plugin.py:79: PytestDeprecationWarning: The hookimpl pytest_cmdline_main uses old-style configuration options (marks or attributes).
  Please use the pytest.hookimpl(tryfirst=True) decorator instead
   to configure the hooks.
   See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers
    @pytest.mark.tryfirst
```
This PR provides the fix.