### PR TITLE
Feature/combine test durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Adding the `combine-tests` cli command 
 
 ## [0.8.2] - 2024-01-29
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ The splitting algorithm can be controlled with the `--splitting-algorithm` CLI o
 #### slowest-tests
 Lists the slowest tests based on the information stored in the test durations file. See `slowest-tests --help` for more
  information.
+#### combine-tests
+Combine a group of test durations files into a single durations file. See `combine-tests --help` for more
+ information.
 
 ## Interactions with other pytest plugins
 * [`pytest-random-order`](https://github.com/jbasko/pytest-random-order) and [`pytest-randomly`](https://github.com/pytest-dev/pytest-randomly):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 slowest-tests = "pytest_split.cli:list_slowest_tests"
+combine-tests = "pytest_split.cli:run_combine_tests"
 
 [tool.poetry.plugins.pytest11]
 pytest-split = "pytest_split.plugin"

--- a/src/pytest_split/cli.py
+++ b/src/pytest_split/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import glob
 import json
 from typing import TYPE_CHECKING
 
@@ -34,3 +35,67 @@ def _list_slowest_tests(durations: "Dict[str, float]", count: int) -> None:
     )[:count]
     for test, duration in slowest_tests:
         print(f"{duration:.2f} {test}")  # noqa: T201
+
+
+def run_combine_tests() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--durations-path",
+        help=(
+            "Path to the file in which durations are stored, "
+            "default is .test_durations in the current working directory"
+        ),
+        default=".test_durations",
+        type=str,
+    )
+    parser.add_argument(
+        "--durations-pattern",
+        help=(
+            "Pattern to match the files in which durations are stored, "
+            "default is */.test_durations in the current working directory"
+        ),
+        default="*/.test_durations",
+        type=str,
+    )
+    parser.add_argument(
+        '--keep_original',
+        action='store_true',
+        default=False
+    )
+
+    args = parser.parse_args()
+    return _run_combine_tests(args.durations_path, args.durations_pattern,args.keep_original)
+
+
+def _run_combine_tests(durations_path: str, durations_pattern: str, keep_original: bool) -> None:
+    """
+    Combines JSON files matching a pattern into a single object and writes it to an output file.
+
+    Args:
+        durations_pattern (str): A file pattern (e.g., "data_*.json") to match JSON files.
+        durations_path (str): The path to the output file where the combined data will be written.
+
+    """
+    combined_data = {}
+    filenames = glob.glob(durations_pattern)
+    if not filenames:
+        print(f"No file found with pattern {durations_pattern}")
+        return
+
+    for filename in filenames:
+        try:
+            with open(filename, 'r') as f:
+                data = json.load(f)
+            combined_data.update(data)  # Efficiently merge dictionaries
+        except (IOError, json.JSONDecodeError) as e:
+            print(f"Error processing file '{filename}': {e}")
+
+    if keep_original:
+        with open(durations_path, 'r') as f:
+            data = json.load(f)
+        combined_data.update(data)
+
+    print(f"{len(filenames)} files combined, with a total of {len(combined_data)} entries")
+
+    with open(durations_path, 'w') as f:
+        json.dump(combined_data, f, indent=4)  # Write with indentation


### PR DESCRIPTION
## Description

Adding a cli command do combine several test durations files into one single file.
Useful when running parallel jobs in GH actions and after want to combine all changes into a single file.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the changes are too minor to be documented
- [ ] The Changes are listed in the `CHANGELOG.md` OR the changes are insignificant
