### PR TITLE
Fix test failure in Python 3.14a

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -5,6 +5,7 @@ from typing import ClassVar
 
 import pytest
 from _pytest.main import ExitCode  # type: ignore[attr-defined]
+from pytest_split.algorithms import Algorithms
 
 pytest_plugins = ["pytester"]
 
@@ -353,10 +354,11 @@ class TestRaisesUsageErrors:
         assert result.ret == ExitCode.USAGE_ERROR
 
         outerr = capsys.readouterr()
-        assert (
-            "argument --splitting-algorithm: invalid choice: 'NON_EXISTENT' "
-            "(choose from 'duration_based_chunks', 'least_duration')"
-        ) in outerr.err
+        for err_content in [
+            "argument --splitting-algorithm: invalid choice: 'NON_EXISTENT' ",
+            *Algorithms.names(),
+        ]:
+            assert err_content in outerr.err
 
 
 class TestHasExpectedOutput:


### PR DESCRIPTION
Due to recent changes in argparse error message construction the test
that checks for the non-existing split algorithm was failing.
python/cpython#117766

Fixed with a lenient error string check with an additional dynamic algorithm
check.

In 3.14, the argparse starts using `str()` instead of `repr()`, which changes the following error output.

```
"(choose from 'duration_based_chunks', 'least_duration')"
```
to 
```
"(choose from duration_based_chunks, least_duration)"
```