### PR TITLE
fix least duration algo with random ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The `least_duration` algorithm now splits deterministically regardless of the starting test order, even in cases where identically named test cases exist.
 
 ## [0.10.0] - 2024-10-16
 ### Added

--- a/src/pytest_split/algorithms.py
+++ b/src/pytest_split/algorithms.py
@@ -63,7 +63,7 @@ class LeastDurationAlgorithm(AlgorithmBase):
 
         # Sort by name to ensure it's always the same order
         items_with_durations_indexed = sorted(
-            items_with_durations_indexed, key=lambda tup: str(tup[0])
+            items_with_durations_indexed, key=lambda tup: tup[0].nodeid
         )
 
         # sort in ascending order


### PR DESCRIPTION
## Description

Hi!

I found a rather critical bug in the least duration algorithm when running together with random ordering and when durations does not exist. The issue arises from the way pytest represents a test case item. It uses only the [test case name](https://github.com/pytest-dev/pytest/blob/fc56ae365fcdea800f91683186136a8191e22399/src/_pytest/nodes.py#L240). In the least duration algorithm you use the [string representation of the test item to sort the test cases](https://github.com/jerry-git/pytest-split/blob/fb9af7e0122c18a96a7c01ca734c4ab01027f8d9/src/pytest_split/algorithms.py#L66) to ensure deterministic groups even when random order is applied. Due to the fact that only the name is used for ordering, the split groups become undeterministic (depending on the initial order) in those cases when there are multiple tests with same name in different modules and durations does not exist. This leads to repeated and skipped tests when used in CI for example.

A very simple solution would be to use the nodeid to sort the tests which I tested and implemented in this PR. I hope you find it OK but if modifications needed I am happy to do that.

## Checklist

- [✅ ] Tests covering the new functionality have been added
- [❌  ] Documentation has been updated OR the changes are too minor to be documented
- [✅  ] The Changes are listed in the `CHANGELOG.md` OR the changes are insignificant
