### PR TITLE
Allow to use pytest 9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ packages = [{ include = 'pytest_split', from = 'src' }]
 
 [tool.poetry.dependencies]
 python = ">=3.8.1, <4.0"
-pytest = "^5 | ^6 | ^7 | ^8"
+pytest = "^5 | ^6 | ^7 | ^8 | ^9"
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
New version was released - https://github.com/pytest-dev/pytest/releases/tag/9.0.0
