### PR TITLE
Make STORE_DURATIONS_SETUP_AND_TEARDOWN_THRESHOLD a controllable env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Fixed
 - Fix malformed bullet points rendering in GitHub Pages documentation
+- Make `STORE_DURATIONS_TEARDOWN_THRESHOLD` controllable through an environment variable.
 
 ## [0.11.0] - 2026-02-03
 ### Added

--- a/src/pytest_split/plugin.py
+++ b/src/pytest_split/plugin.py
@@ -17,7 +17,9 @@ if TYPE_CHECKING:
 
 
 # Ugly hack for freezegun compatibility: https://github.com/spulec/freezegun/issues/286
-STORE_DURATIONS_SETUP_AND_TEARDOWN_THRESHOLD = 60 * 10  # seconds
+STORE_DURATIONS_SETUP_AND_TEARDOWN_THRESHOLD = float(
+    os.environ.get("PYTEST_SPLIT_SETUP_TEARDOWN_THRESHOLD", 60 * 10)
+)  # seconds
 
 
 def pytest_addoption(parser: "Parser") -> None:


### PR DESCRIPTION
## Description

@jerry-git thank you for developing such a useful package!

From some testing, I found that we can mostly achieve the goals of https://github.com/jerry-git/pytest-split/issues/106 (ignoring class setup time) by modifying the `STORE_DURATIONS_TEARDOWN_THRESHOLD` value in `src/pytest_split/plugin.py`. This is a tiny change to just make that constant controllable through an environment variable.

## Checklist

- [ ] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the changes are too minor to be documented
- [ ] The Changes are listed in the `CHANGELOG.md` OR the changes are insignificant
