### PR TITLE
2/5 refactor: assert TestGroup directly in algorithm tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,8 @@ jobs:
       - uses: ./.github/actions/python-poetry-env
         with:
           python-version: ${{ matrix.python-version }}
-      - run: poetry run pytest
+      - run: poetry run coverage run -m pytest
+      - run: poetry run coverage report
 
   docs:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,16 +63,12 @@ pytest-split = "pytest_split.plugin"
 target-version = ["py310", "py311", "py312", "py313", "py314"]
 include = '\.pyi?$'
 
-[tool.pytest.ini_options]
-addopts = """\
-    --cov pytest_split \
-    --cov tests \
-    --cov-report term-missing \
-    --no-cov-on-fail \
-"""
+[tool.coverage.run]
+source = ["pytest_split"]
 
 [tool.coverage.report]
-fail_under = 90
+fail_under = 95
+show_missing = true
 exclude_lines = [
     'if TYPE_CHECKING:',
     'pragma: no cover'

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 from pytest_split.algorithms import (
     AlgorithmBase,
     Algorithms,
+    TestGroup,
 )
 
 item = namedtuple("item", "nodeid")  # noqa: PYI024
@@ -21,20 +22,25 @@ class TestAlgorithms:
         durations = {"a": 1, "b": 1, "c": 1}
         items = [item(x) for x in durations]
         algo = Algorithms[algo_name].value
+
         first, second, third = algo(splits=3, items=items, durations=durations)
 
         # each split should have one test
-        assert first.selected == [item("a")]
-        assert first.deselected == [item("b"), item("c")]
-        assert first.duration == 1
-
-        assert second.selected == [item("b")]
-        assert second.deselected == [item("a"), item("c")]
-        assert second.duration == 1
-
-        assert third.selected == [item("c")]
-        assert third.deselected == [item("a"), item("b")]
-        assert third.duration == 1
+        assert first == TestGroup(
+            selected=[item("a")],
+            deselected=[item("b"), item("c")],
+            duration=1,
+        )
+        assert second == TestGroup(
+            selected=[item("b")],
+            deselected=[item("a"), item("c")],
+            duration=1,
+        )
+        assert third == TestGroup(
+            selected=[item("c")],
+            deselected=[item("a"), item("b")],
+            duration=1,
+        )
 
     @pytest.mark.parametrize("algo_name", Algorithms.names())
     def test__split_tests_handles_tests_in_durations_but_missing_from_items(
@@ -43,39 +49,83 @@ class TestAlgorithms:
         durations = {"a": 1, "b": 1}
         items = [item(x) for x in ["a"]]
         algo = Algorithms[algo_name].value
-        splits = algo(splits=2, items=items, durations=durations)
 
-        first, second = splits
-        assert first.selected == [item("a")]
-        assert second.selected == []
+        first, second = algo(splits=2, items=items, durations=durations)
+
+        assert first == TestGroup(
+            selected=[item("a")], deselected=[], duration=1
+        )
+        assert second == TestGroup(
+            selected=[], deselected=[item("a")], duration=0
+        )
 
     @pytest.mark.parametrize("algo_name", Algorithms.names())
     def test__split_tests_handles_tests_with_missing_durations(self, algo_name):
         durations = {"a": 1}
         items = [item(x) for x in ["a", "b"]]
         algo = Algorithms[algo_name].value
-        splits = algo(splits=2, items=items, durations=durations)
 
-        first, second = splits
-        assert first.selected == [item("a")]
-        assert second.selected == [item("b")]
+        first, second = algo(splits=2, items=items, durations=durations)
+
+        assert first == TestGroup(
+            selected=[item("a")], deselected=[item("b")], duration=1
+        )
+        assert second == TestGroup(
+            selected=[item("b")], deselected=[item("a")], duration=1
+        )
 
     def test__split_test_handles_large_duration_at_end(self):
         """NOTE: only least_duration does this correctly"""
         durations = {"a": 1, "b": 1, "c": 1, "d": 3}
         items = [item(x) for x in ["a", "b", "c", "d"]]
         algo = Algorithms["least_duration"].value
-        splits = algo(splits=2, items=items, durations=durations)
 
-        first, second = splits
-        assert first.selected == [item("d")]
-        assert second.selected == [item(x) for x in ["a", "b", "c"]]
+        first, second = algo(splits=2, items=items, durations=durations)
+
+        assert first == TestGroup(
+            selected=[item("d")],
+            deselected=[item("a"), item("b"), item("c")],
+            duration=3,
+        )
+        assert second == TestGroup(
+            selected=[item("a"), item("b"), item("c")],
+            deselected=[item("d")],
+            duration=3,
+        )
 
     @pytest.mark.parametrize(
         ("algo_name", "expected"),
         [
-            ("duration_based_chunks", [[item("a"), item("b")], [item("c"), item("d")]]),
-            ("least_duration", [[item("a"), item("c")], [item("b"), item("d")]]),
+            (
+                "duration_based_chunks",
+                [
+                    TestGroup(
+                        selected=[item("a"), item("b")],
+                        deselected=[item("c"), item("d")],
+                        duration=2,
+                    ),
+                    TestGroup(
+                        selected=[item("c"), item("d")],
+                        deselected=[item("a"), item("b")],
+                        duration=2,
+                    ),
+                ],
+            ),
+            (
+                "least_duration",
+                [
+                    TestGroup(
+                        selected=[item("a"), item("c")],
+                        deselected=[item("b"), item("d")],
+                        duration=2,
+                    ),
+                    TestGroup(
+                        selected=[item("b"), item("d")],
+                        deselected=[item("a"), item("c")],
+                        duration=2,
+                    ),
+                ],
+            ),
         ],
     )
     def test__split_tests_calculates_avg_test_duration_only_on_present_tests(
@@ -88,23 +138,43 @@ class TestAlgorithms:
         durations = {"b": 1, "c": 1, "d": 1, "e": 10000}
         items = [item(x) for x in ["a", "b", "c", "d"]]
         algo = Algorithms[algo_name].value
-        splits = algo(splits=2, items=items, durations=durations)
 
-        first, second = splits
-        expected_first, expected_second = expected
-        assert first.selected == expected_first
-        assert second.selected == expected_second
+        groups = algo(splits=2, items=items, durations=durations)
+
+        assert groups == expected
 
     @pytest.mark.parametrize(
         ("algo_name", "expected"),
         [
             (
                 "duration_based_chunks",
-                [[item("a"), item("b"), item("c"), item("d"), item("e")], []],
+                [
+                    TestGroup(
+                        selected=[item(x) for x in "abcde"],
+                        deselected=[],
+                        duration=10014,
+                    ),
+                    TestGroup(
+                        selected=[],
+                        deselected=[item(x) for x in "abcde"],
+                        duration=0,
+                    ),
+                ],
             ),
             (
                 "least_duration",
-                [[item("e")], [item("a"), item("b"), item("c"), item("d")]],
+                [
+                    TestGroup(
+                        selected=[item("e")],
+                        deselected=[item(x) for x in "dcba"],
+                        duration=10000,
+                    ),
+                    TestGroup(
+                        selected=[item(x) for x in "abcd"],
+                        deselected=[item("e")],
+                        duration=14,
+                    ),
+                ],
             ),
         ],
     )
@@ -112,12 +182,10 @@ class TestAlgorithms:
         durations = {"a": 2, "b": 3, "c": 4, "d": 5, "e": 10000}
         items = [item(x) for x in ["a", "b", "c", "d", "e"]]
         algo = Algorithms[algo_name].value
-        splits = algo(splits=2, items=items, durations=durations)
 
-        first, second = splits
-        expected_first, expected_second = expected
-        assert first.selected == expected_first
-        assert second.selected == expected_second
+        groups = algo(splits=2, items=items, durations=durations)
+
+        assert groups == expected
 
     def test__split_tests_same_set_regardless_of_order(self):
         """NOTE: only least_duration does this correctly"""


### PR DESCRIPTION
Second of five stacked PRs that fix #25. The end goal is to extend stable group membership (already true for `least_duration` since 0.8.0) to `duration_based_chunks`. This PR is preparation: it makes test assertions easier to evolve as later PRs change algorithm output.

**Motivation.** The downstream PRs change algorithm output ordering and add new fields to verify (durations, deselected lists). The existing per-attribute style would either need lots of new lines per assertion or would obscure mismatches when only one field is wrong. Consolidating to whole-`TestGroup` equality up-front means every later PR adds value to the same assertion shape.

**What changes.** Tests in `tests/test_algorithms.py` previously asserted each `TestGroup` field separately:

```python
assert first.selected == [...]
assert first.deselected == [...]
assert first.duration == ...
```

After:

```python
assert first == TestGroup(selected=[...], deselected=[...], duration=...)
```

Concrete values for every field, not just `selected`.

**Stack.**
- 1/5 — measure coverage on source only via `coverage run` → #120
- 2/5 — this PR — assert `TestGroup` directly
- 3/5 — durations dict signature → #122
- 4/5 — extract within-group ordering → #123
- 5/5 — stabilise `duration_based_chunks` — closes #25 → #124
