### PR TITLE
Add support for Python 3.15 and fix deprecation warnings

### DIFF
--- a/.github/actions/python-poetry-env/action.yml
+++ b/.github/actions/python-poetry-env/action.yml
@@ -13,6 +13,9 @@ runs:
     - uses: actions/setup-python@v5
       with:
         python-version: ${{inputs.python-version}}
+        allow-prereleases: true
+        cache: 'pip'
+        cache-dependency-path: 'poetry.lock'
     - name: Install poetry
       run: python -m pip install poetry
       shell: bash

--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -8,9 +8,9 @@ jobs:
   auto-update-project:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -68,7 +68,7 @@ jobs:
           # a PAT is required to be able to update workflows
           GITHUB_TOKEN: ${{ secrets.AUTO_UPDATE_GITHUB_TOKEN }}
         if: ${{ steps.changes.outputs.changed > 0 && env.GITHUB_TOKEN != 0 }}
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ env.GITHUB_TOKEN }}
           commit-message: >-

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -8,7 +8,7 @@ jobs:
   auto-update-dependencies:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/python-poetry-env
 
       - name: Install tabulate
@@ -46,7 +46,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ steps.check_for_outdated_dependencies.outputs.body != 0 }}
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ env.GITHUB_TOKEN }}
           commit-message: >-

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -12,7 +12,7 @@ jobs:
   draft-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/python-poetry-env
       - name: Update version
         id: updated_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/python-poetry-env
       - name: Publish to pypi
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/python-poetry-env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - "**"
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Download actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.6.21
         shell: bash
@@ -22,14 +22,14 @@ jobs:
     name: Check if automatic project update was successful
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Fail if .rej files exist as structure update was not successful
         run: test -z "$(find . -iname '*.rej')"
 
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/python-poetry-env
       - run: poetry run pre-commit run --all-files
 
@@ -40,7 +40,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/python-poetry-env
         with:
           python-version: ${{ matrix.python-version }}
@@ -49,6 +49,6 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/python-poetry-env
       - run: poetry run mkdocs build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for Python 3.15
+
 ### Fixed
 - Fix malformed bullet points rendering in GitHub Pages documentation
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -799,19 +799,19 @@ type = ["mypy (>=1.8)"]
 
 [[package]]
 name = "pluggy"
-version = "1.5.0"
+version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
-    {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
 ]
 
 [package.extras]
 dev = ["pre-commit", "tox"]
-testing = ["pytest", "pytest-benchmark"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Typing :: Typed",
 ]
@@ -60,7 +61,7 @@ slowest-tests = "pytest_split.cli:list_slowest_tests"
 pytest-split = "pytest_split.plugin"
 
 [tool.black]
-target-version = ["py310", "py311", "py312", "py313", "py314"]
+target-version = ["py310", "py311", "py312", "py313", "py314", "py315"]
 include = '\.pyi?$'
 
 [tool.pytest.ini_options]

--- a/src/pytest_split/cli.py
+++ b/src/pytest_split/cli.py
@@ -11,7 +11,6 @@ def list_slowest_tests() -> None:
             "default is .test_durations in the current working directory"
         ),
         default=".test_durations",
-        type=argparse.FileType(),
     )
     parser.add_argument(
         "-c",
@@ -21,7 +20,9 @@ def list_slowest_tests() -> None:
         type=int,
     )
     args = parser.parse_args()
-    return _list_slowest_tests(json.load(args.durations_path), args.count)
+    with open(args.durations_path) as f:
+        durations = json.load(f)
+    return _list_slowest_tests(durations, args.count)
 
 
 def _list_slowest_tests(durations: "dict[str, float]", count: int) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,8 +14,7 @@ def durations_file(tmpdir):
     durations = {f"test_{i}": float(i) for i in range(1, 11)}
     with open(durations_path, "w") as f:
         json.dump(durations, f)
-    with open(durations_path) as f:
-        yield f
+    return durations_path
 
 
 def test_slowest_tests(durations_file):


### PR DESCRIPTION
## Description
The Python 3.15 beta is out. 🚀 

The 3.15 release manager (👋 hi, that's me!) [said](https://discuss.python.org/t/python-3-15-0-beta-3-is-here/107866):

> We ***strongly encourage*** maintainers of third-party Python projects to ***test with 3.15*** during the beta phase and report issues found to [the Python bug tracker](https://github.com/python/cpython/issues) as soon as possible. While the release is planned to be feature-complete entering the beta phase, it is possible that features may be modified or, in rare cases, removed up until the start of the release candidate phase (2026-08-04). Our goal is to have ***no ABI changes*** after beta 4 and as few code changes as possible after the first release candidate. To achieve that, it will be ***extremely important*** to get as much exposure for 3.15 as possible during the beta phase.
> 
> This includes creating pre-release wheels for 3.15, as it helps other projects to do their own testing. However, we recommend that your regular production releases wait until 3.15.0rc1, to avoid the risk of ABI breaks.

Also fix `PendingDeprecationWarning: FileType is deprecated. Simply open files after parsing arguments.` starting in Python 3.14, and bump pluggy in the lockfile to fix `SyntaxWarning: 'return' in a 'finally' block`.

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Documentation has been updated OR the changes are too minor to be documented
- [x] The Changes are listed in the `CHANGELOG.md` OR the changes are insignificant
